### PR TITLE
long code layout fix

### DIFF
--- a/assets/css/fontforge.css
+++ b/assets/css/fontforge.css
@@ -8,6 +8,9 @@ pre {
 	white-space: pre;
 	overflow: auto;
 }
+code {
+	word-wrap: break-word;
+}
 
 .ff-download .dl {
 	display: none;


### PR DESCRIPTION
code text such as 

/Applications/FontForge.app/Contents/Resources/opt/local/share/fontforge/hotkeys/default

will currently break the layout on narrow browser windows
