### PR TITLE
Update GitHub reop url

### DIFF
--- a/en-US/about/site.md
+++ b/en-US/about/site.md
@@ -22,7 +22,7 @@ To contribute to the site beyond simply editing the text, such as to adjust the 
 
 If that sounds unfamiliar, GitHub has excellent [bootcamp tutorials](https://help.github.com/categories/54/articles) (that really are excellent) to get you going. Here's the project link on GitHub:
 
-> [https://github.com/fontforge/fontforge.github.com](https://github.com/fontforge/fontforge.github.com)
+> [https://github.com/fontforge/fontforge.github.io](https://github.com/fontforge/fontforge.github.io)
 
 <a id="translations"></a>
 


### PR DESCRIPTION
The link to the website repository is using the depreciated github.com url.
Have updated this to reflect the new github.io url.
