### PR TITLE
nav-main.html

### DIFF
--- a/_includes/nav-main.html
+++ b/_includes/nav-main.html
@@ -29,9 +29,9 @@
 				<div class="nav-collapse collapse">
 					<ul class="nav">
 						<li class="downloads"><a href="/en-US/downloads/">Download</a></li>
-						<li class="tutorials"><a href="http://designwithfontforge.com/">Tutorial</a></li>
+						<li class="tutorials"><a href="http://designwithfontforge.com/" target="_blank" style="cursor: alias">Tutorial </a></li>
 						<li class="docs"><a href="/en-US/documentation/">Documentation</a></li>
-						<li class="about"><a href="http://github.com/fontforge/fontforge">Development</a></li>
+						<li class="about"><a href="/en-US/documentation/developers/">Development</a></li>
 					</ul>
 				</div>
 			</div>


### PR DESCRIPTION
- open DWFF in new window, with cursor indication
- development section to link to /en-US/documentation/developers/ instead of github project (which just links there anyway)