### PR TITLE
auto-redirect to the download page

### DIFF
--- a/en-US/downloads/gnulinux.md
+++ b/en-US/downloads/gnulinux.md
@@ -48,6 +48,8 @@ Thanks. Continue <a href="../gnulinux-dl">this way</a>.
 function downloadClicked() {
 	document.getElementById("emls_box").style.display = "none";
 	document.getElementById("dl_continue_box").style.display = "inline";
+	window.location.href = "http://fontforge.github.io/en-US/downloads/gnulinux-dl/";
+
 }
 function subscribeClicked() {
 	document.forms["emls_sform"]["email"].value = document.forms["emls_vform"]["email"].value;


### PR DESCRIPTION
this can get a problem when safari warns about non secure form and confirms "send" 