### PR TITLE
Fix word repetion in all the docs

### DIFF
--- a/archive/TrueOpenTables.html
+++ b/archive/TrueOpenTables.html
@@ -226,7 +226,7 @@
       <TD>gasp</TD>
       <TD>grid-fitting and scan conversion</TD>
       <TD>When FontForge does not attempt to hint a truetype font it will generate
-	this table which tells the rasterizer not to to do grid-fitting (hinting)
+	this table which tells the rasterizer not to do grid-fitting (hinting)
 	but to do anti-aliasing instead.</TD>
       <TD><P ALIGN=Center>
 	<A HREF="http://developer.apple.com/fonts/TTRefMan/RM06/Chap6gasp.html">gasp</A></TD>

--- a/archive/bezier.html
+++ b/archive/bezier.html
@@ -159,7 +159,7 @@
   "evenly" into n quadratic splines (here n==3) then the control points will
   have the nice property that the on-curve points are exactly mid-way between
   control points -- this means that truetype can represent them as interpolated
-  points. An even division means means that each sub-point is placed where
+  points. An even division means that each sub-point is placed where
   t=i/n (where 0&lt;i&lt;n).
   <P>
   FontForge first checks to see if the curve is already a quadratic -- this

--- a/archive/charview.html
+++ b/archive/charview.html
@@ -830,7 +830,7 @@
   <P>
   The image to the right shows an example of this mode. You invoke it with
   <CODE><A HREF="hintsmenu.html#Debug">Hints-&gt;Debug</A></CODE>, and as with
-  the grid-fit view above you must establish a pointsize and and resolution.
+  the grid-fit view above you must establish a pointsize and resolution.
   The view divides into two panes, the left of which is similar to the grid
   fit view above (except that it changes as you step through the instructions),
   the right pane provides a list of the instructions to be executed.

--- a/archive/editexample-full.html
+++ b/archive/editexample-full.html
@@ -1305,8 +1305,8 @@
   <P>
   We have three rules, each rule lives in its own subtable, so we will create
   three subtables, one for each. The order in which these subtables n the Lookups
-  pane is important because that is the order in which the the rules they contain
-  will be executed. We must insure that that final rule which actually invokes
+  pane is important because that is the order in which the rules they contain
+  will be executed. We must insure that final rule which actually invokes
   the ligature is the last one executed (and the last one in the
   list).<BR CLEAR=ALL>
   <TABLE BORDER CELLPADDING="2">

--- a/archive/editexample6-5.html
+++ b/archive/editexample6-5.html
@@ -361,7 +361,7 @@
   We have three rules, each rule lives in its own subtable, so we will create
   three subtables, one for each. The order in which these subtables n the Lookups
   pane is important because that is the order in which the rules they contain
-  will be executed. We must insure that that final rule which actually invokes
+  will be executed. We must insure that final rule which actually invokes
   the ligature is the last one executed (and the last one in the
   list).<BR CLEAR=ALL>
   <TABLE BORDER CELLPADDING="2">

--- a/archive/faq.html
+++ b/archive/faq.html
@@ -477,7 +477,7 @@
       work out which is which... (Ironically the most frequent complaint I get
       is from people who can't tell whether my checkboxes are checked. I don't
       know what to make of that).<BR>
-      I realize now that that there are essentially two free widget sets that are
+      I realize now that there are essentially two free widget sets that are
       far better at unicode support than mine. These are
       <A HREF="http://www.trolltech.com/developer/downloads/qt">QT</A> and
       <A HREF="http://www.gtk.org/">gtk</A>. I'm still not using either because:

--- a/archive/ff-history.html
+++ b/archive/ff-history.html
@@ -446,10 +446,10 @@
   svg) fonts.
   <P>
   In June I was thinking of the embolden command I did the year before, and
-  realized that that was essentially the same idea as was needed for generating
+  realized that was essentially the same idea as was needed for generating
   Small Caps glyphs from Capital letters. And then some of those algorithms
   could be used to create condensed and extended glyphs. And then I sat down
-  and wrote a generic "glyph change" dialog -- years ago I had had a "MetaFont"
+  and wrote a generic "glyph change" dialog -- years ago I had a "MetaFont"
   command which was supposed to allow the user to embolden fonts for condense
   them or ... Unfortunately my MetaFont never worked very well (And some users
   complained that It didn't read Knuth's mf files. Sigh. No, it metamorphosed

--- a/archive/lookups.html
+++ b/archive/lookups.html
@@ -351,7 +351,7 @@ allowable amount of cumuliative error between two glyphs before they must
 be in separate classes.
 <P>
 The <CODE>Default Separation</CODE> and <CODE>Min Kern</CODE> fields are
-used in AutoKerning. The goal of kerning to to make the optical separation
+used in AutoKerning. The goal of kerning to make the optical separation
 between all glyphs to be constant, and the <CODE>Default Separation
 </CODE>field specifies that desired value. The <CODE>Min Kern</CODE> value
 is simply to prevent the dialog from filling with useless junk. If AutoKerning

--- a/archive/metricsview.html
+++ b/archive/metricsview.html
@@ -719,7 +719,7 @@
   a 1000em font) is fairly loose.
   <P>
   The <CODE>Default Separation</CODE> and <CODE>Min Kern</CODE> fields are
-  used in AutoKerning. The goal of kerning to to make the optical separation
+  used in AutoKerning. The goal of kerning to make the optical separation
   between all glyphs to be constant, and the <CODE>Default Separation
   </CODE>field specifies that desired value. The <CODE>Min Kern</CODE> value
   is simply to prevent the dialog from filling with useless junk. If AutoKerning

--- a/archive/oldchangelog.html
+++ b/archive/oldchangelog.html
@@ -208,7 +208,7 @@
 	  table. (Needed because of a bug which introduced garbage).
 	<LI>
 	  We didn't think we could read in a kerning subtable (class or pair) with
-	  device tables, so we converted them to pst data. We can read them in in optimized
+	  device tables, so we converted them to pst data. We can read them in optimized
 	  form and we should do so.
 	<LI>
 	  Alexej points out that if a glyph has "instructions_out_of_date" set on it,
@@ -3151,7 +3151,7 @@ $ make install_gtk
 	  synchronized to dependent glyphs.
 	<LI>
 	  Enforce the "Use My Metrics" bit of a reference.<BR>
-	  In TrueType, if this bit is set on a reference then then width of the containing
+	  In TrueType, if this bit is set on a reference then width of the containing
 	  glyph will be the same as that of the reference.<BR>
 	  So don't let the user change the width of such glyphs. (and add a lock icon
 	  to the width line in the character view to show that it is fixed).

--- a/archive/pfaeditmath.html
+++ b/archive/pfaeditmath.html
@@ -625,7 +625,7 @@
   another easy transformation).
   <P>
   When we reach a point where the spline's slope is parallel to one edge of
-  the pen, then on the outside path we draw a copy of that edge of of the pen,
+  the pen, then on the outside path we draw a copy of that edge of the pen,
   and on the inside edge we calculate a join as above.
   <H3>
     An arbitrary convex polygonal pen

--- a/archive/prefs.html
+++ b/archive/prefs.html
@@ -147,7 +147,7 @@
       "On" because it does not get in the way and will ensure that the
       correct extension is given to your font files as you work on
       them. This makes it much harder to accidentally ship a
-      Fontforge SFD file as as binary file or try to use an SFD format
+      Fontforge SFD file as binary file or try to use an SFD format
       file as a binary font file.
   </DL>
   <P>

--- a/archive/problems.html
+++ b/archive/problems.html
@@ -258,7 +258,7 @@
     <STRONG>Refs Deeper Than</STRONG>
   </H3>
   <P>
-  Appendix B of the the
+  Appendix B of the
   <A HREF="http://partners.adobe.com/asn/developer/pdfs/tn/5177.Type2.pdf">Type2</A>
   spec says that an interpreter is only required to support subroutine nesting
   up to 10 levels. FontForge uses subroutine calls to handle referenced glyphs
@@ -329,7 +329,7 @@
     <STRONG>More Hints Than</STRONG>
   </H3>
   <P>
-  Appendix B of the the
+  Appendix B of the
   <A HREF="http://partners.adobe.com/asn/developer/pdfs/tn/5177.Type2.pdf">Type2</A>
   spec says that an interpreter is only required to support a total of 96
   horizontal and vertical hints.
@@ -354,7 +354,7 @@
   If you have a font with embedded bitmaps, then you would expect that the
   bitmap advance width would be the same as the outline glyph's advance width
   (with approprate scaling and rounding, of course). This checks to ensure
-  that that is true.
+  that is true.
   <P>
   <STRONG><BIG>Check Multiple Unicode</BIG></STRONG>
   <P>

--- a/archive/python.html
+++ b/archive/python.html
@@ -3055,7 +3055,7 @@ This type may not be pickled.
     <TR>
       <TD><CODE>guess</CODE></TD>
       <TD><CODE>(name)</CODE></TD>
-      <TD>Guess a value for this this entry in the private dictionary. If fontforge
+      <TD>Guess a value for this entry in the private dictionary. If fontforge
 	can't make a guess it will simply ignore the request.</TD>
     </TR>
   </TABLE>
@@ -4052,7 +4052,7 @@ This type may not be pickled.
 	kerning values will be inserted into the table.
 	<P>
 	In the third format the user merely specifies two lists of glyphs to be used,
-	fontforge will look for similarities among among the glyphs and guess at
+	fontforge will look for similarities among the glyphs and guess at
 	classes. The class-distance argument to determine how precise the classes
 	should match (1 is very tight matching, 20 is rather loose).
 	<P>

--- a/archive/running.html
+++ b/archive/running.html
@@ -258,7 +258,7 @@ setenv PATH /usr/local/bin:$PATH
   <P>
   <FONT COLOR="Red"><STRONG>Caveat: </STRONG></FONT>FontForge does not normally
   show mac resource fonts in this dialog -- however it can still open one even
-  it it isn't displayed. Simply type in the name of the file containing it.
+  if it isn't displayed. Simply type in the name of the file containing it.
   (or change the Filter field to "All Files").
   <P>
   If the Applications menu does not contain a "FontForge" entry, you can add

--- a/archive/scripting.html
+++ b/archive/scripting.html
@@ -1234,7 +1234,7 @@ endloop
     <LI>
       <A HREF="scripting-alpha.html#SetPref">SetPref(str,val[,val2])</A>
     <LI>
-      It it also possible to get the value of a preference item by preceding its
+      It is also possible to get the value of a preference item by preceding its
       name with a dollar sign.
   </UL>
   <H3 ALIGN=Center>

--- a/archive/sfdformat.html
+++ b/archive/sfdformat.html
@@ -972,7 +972,7 @@ EndChar
   The entry <CODE>Fore</CODE> starts the foreground
   <A NAME="splineset">splines</A>, they are encoded as postscript commands
   with moveto abbreviated to m, curveto to c and lineto to l (lower case el).
-  The digit after after the letter is a set of flags whose bits have the following
+  The digit after the letter is a set of flags whose bits have the following
   meanings:
   <TABLE CELLPADDING="2">
     <TR>

--- a/archive/viewmenu.html
+++ b/archive/viewmenu.html
@@ -467,7 +467,7 @@
 	  in, in the current encoding
 	<LI>
 	  A hex number ,preceded by "U+" or "uni" or "u", indicating the character
-	  you are interested in in unicode.
+	  you are interested in unicode.
 	<LI>
 	  A decimal number, preceded by "glyph" ,indicating the glyph index in the
 	  original glyph list.

--- a/docs/appendices/ff-history.html
+++ b/docs/appendices/ff-history.html
@@ -395,10 +395,10 @@ FontForge grew multiple layer support.</p>
 And to amuse myself I added the ablity to have gradient fills in Type3 (and svg)
 fonts.</p>
 <p>In June I was thinking of the embolden command I did the year before, and
-realized that that was essentially the same idea as was needed for generating
+realized that was essentially the same idea as was needed for generating
 Small Caps glyphs from Capital letters. And then some of those algorithms could
 be used to create condensed and extended glyphs. And then I sat down and wrote a
-generic “glyph change” dialog – years ago I had had a “MetaFont” command which
+generic “glyph change” dialog – years ago I had a “MetaFont” command which
 was supposed to allow the user to embolden fonts for condense them or …
 Unfortunately my MetaFont never worked very well (And some users complained that
 It didn’t read Knuth’s mf files. Sigh. No, it metamorphosed fonts in its own

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -295,7 +295,7 @@ checkbox was checked or not checked. In far too many cases my eyes can’t work
 out which is which… (Ironically the most frequent complaint I get is from
 people who can’t tell whether my checkboxes are checked. I don’t know what to
 make of that).</p>
-<p>I realize now that that there are essentially two free widget sets that are
+<p>I realize now that there are essentially two free widget sets that are
 far better at unicode support than mine. These are
 <a class="reference external" href="http://www.trolltech.com/developer/downloads/qt">QT</a> and
 <a class="reference external" href="http://www.gtk.org/">gtk</a>. I’m still not using either because:</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -473,7 +473,7 @@ a glyph into it’s component splines. The
 reference) will bring up a dialog showing you what glyph is referred to, and
 allowing you to bring up an editing window on that glyph. Finally the
 <a class="reference internal" href="ui/menus/elementmenu.html#elementmenu-accented"><span class="std std-ref">Element-&gt;Build-&gt;Accented Glyphs</span></a> command will
-figure out what glyphs should be refered to to build this composite glyph, and
+figure out what glyphs should be refered to build this composite glyph, and
 then will make those references and position them appropriately. So if “à” were
 selected and you did a
 <a class="reference internal" href="ui/menus/elementmenu.html#elementmenu-accented"><span class="std std-ref">Element-&gt;Build-&gt;Accented Glyphs</span></a> command, FontForge

--- a/docs/old/de/editexample6.html
+++ b/docs/old/de/editexample6.html
@@ -164,7 +164,7 @@
     erlaubt die Eingabe dieser Information.
   <P>
   Dann wird in jedem Zeichen, daß Anhänge besitzen soll, zunächst die
-  Stelle angeklickt, an der der Anker erstellt werden soll und dann der
+  Stelle angeklickt, an der Anker erstellt werden soll und dann der
   Befehl <CODE><A HREF="../../ui/menus/pointmenu.html#AddAnchor">Punkt-&gt;Anker hinzufügen</A></CODE>
   aufgerufen.
   <P>

--- a/docs/old/ja/TrueOpenTables.html
+++ b/docs/old/ja/TrueOpenTables.html
@@ -224,7 +224,7 @@ are essentially the same, while Apple's differ significantly from either. -->
 <!--<TD>grid-fitting and scan conversion</TD>-->
     <TD>グリッド合わせおよびスキャン変換</TD>
 <!--<TD>When FontForge does not attempt to hint a truetype font it will generate
-      this table which tells the rasterizer not to to do grid-fitting (hinting)
+      this table which tells the rasterizer not to do grid-fitting (hinting)
       but to do anti-aliasing instead.</TD> -->
     <TD>FontForge が TrueType フォントのヒントづけを試みない場合、ラスタライザにグリッド合わせ (ヒント処理) を行わずに、アンチエイリアスを行うように指定します。</TD>
     <TD><P ALIGN=Center>

--- a/docs/old/ja/bezier.html
+++ b/docs/old/ja/bezier.html
@@ -187,7 +187,7 @@
   "evenly" into n quadratic splines (here n==3) then the control points will
   have the nice property that the on-curve points are exactly mid-way between
   control points - - this means that truetype can represent them as interpolated
-  points. An even division means means that each sub-point is placed where
+  points. An even division means that each sub-point is placed where
   t=i/n (where 0&lt;i&lt;n). -->
   <IMG src="../../_images/cubic2quad.png" WIDTH="482" HEIGHT="180" ALIGN="Right">私はこれを証明できていませんが、3 次スプラインを——右図の 4 分の 1 楕円のごとく、n 本の 2 次スプライン (図では、n=3) へと——「均等に」分割すれば、その制御点同士の中点が曲線上の点となるのにちょうどよい比率になるということが (そう教えられて) 経験的な測定結果により知られています。これはつまり、TrueType ではそれらが補間された点として表現できるということになります。(「均等な」分割とは、t=i/n (ただし 0&lt;i&lt;n) の位置に点を置くことを指します。)
   <P>

--- a/docs/old/ja/charview.html
+++ b/docs/old/ja/charview.html
@@ -790,7 +790,7 @@
 <!--
   The image to the right shows an example of this mode. You invoke it with
   <CODE><A HREF="hintsmenu.html#Debug">Hints-&gt;Debug</A></CODE>, and as with
-  the grid-fit view above you must establish a pointsize and and resolution.
+  the grid-fit view above you must establish a pointsize and resolution.
   The view divides into two panes, the left of which is similar to the grid
   fit view above (except that it changes as you step through the instructions),
   the right pane provides a list of the instructions to be executed. -->

--- a/docs/old/ja/elementmenu.html
+++ b/docs/old/ja/elementmenu.html
@@ -1067,7 +1067,7 @@
       were "&Agrave;" then a reference to "A" would be added to it, and a reference
       to "`" would be centered above the "A". <BR>
       If <A HREF="editmenu.html#From">Copy From</A> is set to All Fonts then any
-      bitmaps will have a similar process done (even in the outline glyph view view).<BR>    
+      bitmaps will have a similar process done (even in the outline glyph view).<BR>    
       A more complete description is given in the section on
       <A HREF="accented.html">accented glyph</A>. -->
       現在のグリフがアクセントつきグリフであれば (なおかつ基底グリフとアクセントが既に作成してあれば)、このコマンドはグリフの前面に含まれている内容をすべて削除し、基底グリフに対する参照と、アクセントのグリフに対するもう一つの参照を前面に配置します。例えば、現在のグリフが“&Agrave;”であれば、“A”への参照がそのグリフに追加され、“`”への参照が“A”と中心を合わせて配置されるでしょう。<BR>

--- a/docs/old/ja/pfaeditmath.html
+++ b/docs/old/ja/pfaeditmath.html
@@ -598,7 +598,7 @@
   <P>
 <!--
   When we reach a point where the spline's slope is parallel to one edge of
-  the pen, then on the outside path we draw a copy of that edge of of the pen,
+  the pen, then on the outside path we draw a copy of that edge of the pen,
   and on the inside edge we calculate a join as above. -->
   スプラインの傾きがペンの 1 つの辺に平行になる点に達したとき、パスの外側ではペンの輪郭のコピーを描くことになり、内側では上記と同じ方法で結びの点を計算することになります。
   <H3>

--- a/docs/old/ja/problems.html
+++ b/docs/old/ja/problems.html
@@ -313,7 +313,7 @@
   </H3>
   <P>
 <!--
-  Appendix B of the the
+  Appendix B of the
   <A HREF="http://partners.adobe.com/asn/developer/pdfs/tn/5177.Type2.pdf">Type2</A>
   spec says that an interpreter is only required to support subroutine nesting
   up to 10 levels. FontForge uses subroutine calls to handle referenced glyphs
@@ -402,7 +402,7 @@
   </H3>
   <P>
 <!--
-  Appendix B of the the
+  Appendix B of the
   <A HREF="http://partners.adobe.com/asn/developer/pdfs/tn/5177.Type2.pdf">Type2</A>
   spec says that an interpreter is only required to support a total of 96
   horizontal and vertical hints. -->

--- a/docs/old/ja/running.html
+++ b/docs/old/ja/running.html
@@ -250,7 +250,7 @@ setenv PATH /usr/local/bin:$PATH
 <!--
   <FONT COLOR="Red"><STRONG>Caveat: </STRONG></FONT>FontForge does not normally
   show mac resource fonts in this dialog - - however it can still open one even
-  it it isn't displayed. Simply type in the name of the file containing it.
+  if it isn't displayed. Simply type in the name of the file containing it.
   (or, if you prefer, type a "*" in the textfield and then press the [Filter]
   button. This should show you all files). -->
   <FONT COLOR="Red"><STRONG>警告: </STRONG></FONT>FontForge は通常は Mac リソースフォントをこの一覧に表示しません——たとえファイルが表示されていない場合でも、その中の 1 個を開くことは可能です。たんに、そのディレクトリにあるファイルの名前をタイプするだけです (または、そうしたくない場合、テキストフィールドに“*”と入力してから <CODE>[フィルタ]</CODE> ボタンを押してください。すべてのファイルが一覧表示されます)。

--- a/docs/old/ja/scripting.html
+++ b/docs/old/ja/scripting.html
@@ -1309,7 +1309,7 @@ endloop
     <LI>
       <A HREF="scripting-alpha.html#SetPref">SetPref(str,val[,val2])</A>
 <!--
-    <LI>It it also possible to get the value of a preference item by preceding its
+    <LI>It is also possible to get the value of a preference item by preceding its
 name with a dollar sign. -->
     <LI>環境設定項目の値は、項目名の前にドル記号 ($) をつけた名前の変数によって得ることもできます。
   </UL>

--- a/docs/old/ja/sfdformat.html
+++ b/docs/old/ja/sfdformat.html
@@ -743,7 +743,7 @@ EndChar
   The entry <CODE>Fore</CODE> starts the foreground
   <A NAME="splineset">splines</A>, they are encoded as postscript commands
   with moveto abbreviated to m, curveto to c and lineto to l (lower case el).
-  The digit after after the letter is a set of flags whose bits have the following
+  The digit after the letter is a set of flags whose bits have the following
   meanings: -->
   項目 <CODE>Fore</CODE> は前面<A NAME="splineset">スプライン</A>の始まりを指定します。それらは PostScript コマンドで表されますが、moveto を m に、curveto を c に、lineto を l (小文字エル) に省略しています。文字の後ろに来る数値はフラグの組で、各ビットには以下のような意味があります。
   <TABLE CELLPADDING="2">

--- a/docs/old/ja/viewmenu.html
+++ b/docs/old/ja/viewmenu.html
@@ -295,7 +295,7 @@
 	  現在の符号化方式で、注目しているグリフのコードを示す (10 進または 16 進の) 数値
         <LI>
 <!--	  A hex number ,preceded by "U+" or "uni" or "u", indicating the character
-	  you are interested in in unicode. -->
+	  you are interested in unicode. -->
 	  “<CODE>U+</CODE>”または“<CODE>uni</CODE>”または“<CODE>u</CODE>”の後ろに 16 進数を続けたもの。興味あるグリフで表される文字の Unicode でのコードを表します。
         <LI>
 <!--	  A decimal number, preceded by "glyph" ,indicating the glyph index in the

--- a/docs/scripting/python/fontforge.html
+++ b/docs/scripting/python/fontforge.html
@@ -5046,7 +5046,7 @@ glyphs just touch each other). Again the user specifies two sets of
 predefined classes. If the (optional) <code class="docutils literal notranslate"><span class="pre">onlyCloser</span></code> flag is set true then
 only negative kerning values will be inserted into the table.</p>
 <p>In the third format the user merely specifies two lists of glyphs to be
-used, fontforge will look for similarities among among the glyphs and guess
+used, fontforge will look for similarities among the glyphs and guess
 at classes. The class-distance argument to determine how precise the classes
 should match (1 is very tight matching, 20 is rather loose).</p>
 <p>In the last format the font’s selection will be used to specify the list of

--- a/docs/scripting/scripting.html
+++ b/docs/scripting/scripting.html
@@ -1024,7 +1024,7 @@ information.</p>
 <li><p><a class="reference internal" href="scripting-alpha.html#ReadOtherSubrsFile" title="ReadOtherSubrsFile"><code class="xref ff ff-func docutils literal notranslate"><span class="pre">ReadOtherSubrsFile()</span></code></a></p></li>
 <li><p><a class="reference internal" href="scripting-alpha.html#SavePrefs" title="SavePrefs"><code class="xref ff ff-func docutils literal notranslate"><span class="pre">SavePrefs()</span></code></a></p></li>
 <li><p><a class="reference internal" href="scripting-alpha.html#SetPref" title="SetPref"><code class="xref ff ff-func docutils literal notranslate"><span class="pre">SetPref()</span></code></a></p></li>
-<li><p>It it also possible to get the value of a preference item by preceding its name
+<li><p>It is also possible to get the value of a preference item by preceding its name
 with a dollar sign.</p></li>
 </ul>
 </div>

--- a/docs/techref/bezier.html
+++ b/docs/techref/bezier.html
@@ -123,7 +123,7 @@ worked) that if a cubic spline – like the quarter ellipse at right – is
 divided “evenly” into n quadratic splines (here <span class="math notranslate nohighlight">\(n = 3\)</span>) then the control
 points will have the nice property that the on-curve points are exactly mid-way
 between control points – this means that truetype can represent them as
-interpolated points. An even division means means that each sub-point is placed
+interpolated points. An even division means that each sub-point is placed
 where <span class="math notranslate nohighlight">\(t = i/n\)</span> (where <span class="math notranslate nohighlight">\(0&lt;i&lt;n\)</span>).</p>
 <p>FontForge first checks to see if the curve is already a quadratic – this might
 happen if the cubic originally came from a truetype font. If it is it simply

--- a/docs/techref/pfaeditmath.html
+++ b/docs/techref/pfaeditmath.html
@@ -395,7 +395,7 @@ center of the pen, so all we need to do is translate the original spline by this
 distance (and then fix it up so that t goes from [0,1], but that’s another easy
 transformation).</p>
 <p>When we reach a point where the spline’s slope is parallel to one edge of the
-pen, then on the outside path we draw a copy of that edge of of the pen, and on
+pen, then on the outside path we draw a copy of that edge of the pen, and on
 the inside edge we calculate a join as above.</p>
 </div>
 <div class="section" id="an-arbitrary-convex-polygonal-pen">

--- a/docs/techref/sfdformat.html
+++ b/docs/techref/sfdformat.html
@@ -902,7 +902,7 @@ valid.</p>
 <p>specifying the vertical advance width.</p>
 <p id="sfdformat-splineset">The entry <code class="docutils literal notranslate"><span class="pre">Fore</span></code> starts the foreground splines, they are encoded as postscript
 commands with moveto abbreviated to m, curveto to c and lineto to l (lower case
-el). The digit after after the letter is a set of flags whose bits have the
+el). The digit after the letter is a set of flags whose bits have the
 following meanings:</p>
 <dl class="object">
 <dt>

--- a/docs/techref/stroke.html
+++ b/docs/techref/stroke.html
@@ -109,7 +109,7 @@ where the angle changes:</p>
 </div>
 <div class="section" id="caps">
 <span id="stroke-cap"></span><h3>Caps<a class="headerlink" href="#caps" title="Permalink to this headline">¶</a></h3>
-<p>The line that closes the gap between the offset lines traced to the end of of an
+<p>The line that closes the gap between the offset lines traced to the end of an
 open source contour is called a “cap”. PostScript and SVG specify three cap
 styles that are really two styles: “Round” and “Butt”/”Square”. A Round cap
 connects the ends with a semi-circle, while a Butt cap connects them with a

--- a/docs/tutorial/editexample6-5.html
+++ b/docs/tutorial/editexample6-5.html
@@ -242,7 +242,7 @@ be bound to a feature tag in the Greek script.</p>
 <p>We have three rules, each rule lives in its own subtable, so we will create
 three subtables, one for each. The order in which these subtables n the Lookups
 pane is important because that is the order in which the rules they contain will
-be executed. We must insure that that final rule which actually invokes the
+be executed. We must insure that final rule which actually invokes the
 ligature is the last one executed (and the last one in the list).</p>
 <p class="rubric">Steps</p>
 <img alt="../_images/hligbyclasses.png" src="../_images/hligbyclasses.png" />

--- a/docs/ui/dialogs/lookups.html
+++ b/docs/ui/dialogs/lookups.html
@@ -325,7 +325,7 @@ FontForge to pick kerning classes for you, you must specify the maximum
 allowable amount of cumuliative error between two glyphs before they must be in
 separate classes.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">Default</span> <span class="pre">Separation</span></code> and <code class="docutils literal notranslate"><span class="pre">Min</span> <span class="pre">Kern</span></code> fields are used in AutoKerning. The
-goal of kerning to to make the optical separation between all glyphs to be
+goal of kerning to make the optical separation between all glyphs to be
 constant, and the <code class="docutils literal notranslate"><span class="pre">Default</span> <span class="pre">Separation</span></code> field specifies that desired value. The
 <code class="docutils literal notranslate"><span class="pre">Min</span> <span class="pre">Kern</span></code> value is simply to prevent the dialog from filling with useless
 junk. If AutoKerning suggests that two glyphs should be kerned by 1 em unit then

--- a/docs/ui/dialogs/prefs.html
+++ b/docs/ui/dialogs/prefs.html
@@ -402,7 +402,7 @@ accent, or on the center of the bottom of the accent.</p>
 <span class="target" id="prefs-charcenterhighest"></span><dl class="object">
 <dt>
 <code class="sig-name descname">CharCenterHighest</code></dt>
-<dd><p>Whether accents should be positioned over letters based on the center of of
+<dd><p>Whether accents should be positioned over letters based on the center of
 the letter, or on the center of the top of the letter.</p>
 </dd></dl>
 

--- a/docs/ui/dialogs/problems.html
+++ b/docs/ui/dialogs/problems.html
@@ -250,7 +250,7 @@ won’t be in a reference.</p>
 </div>
 <div class="section" id="refs-deeper-than">
 <h2>Refs Deeper Than<a class="headerlink" href="#refs-deeper-than" title="Permalink to this headline">¶</a></h2>
-<p>Appendix B of the the
+<p>Appendix B of the
 <a class="reference external" href="http://partners.adobe.com/asn/developer/pdfs/tn/5177.Type2.pdf">Type2</a> spec
 says that an interpreter is only required to support subroutine nesting up to 10
 levels. FontForge uses subroutine calls to handle referenced glyphs and
@@ -318,7 +318,7 @@ was a stem3 or it might be really far off from a stem3)</p>
 </div>
 <div class="section" id="more-hints-than">
 <h2>More Hints Than<a class="headerlink" href="#more-hints-than" title="Permalink to this headline">¶</a></h2>
-<p>Appendix B of the the
+<p>Appendix B of the
 <a class="reference external" href="http://partners.adobe.com/asn/developer/pdfs/tn/5177.Type2.pdf">Type2</a> spec
 says that an interpreter is only required to support a total of 96 horizontal
 and vertical hints.</p>
@@ -340,7 +340,7 @@ for bitmap fonts with glyphs which are not present in the outline font.</p>
 <h2>Bitmap/Outline Advance Width Mismatch<a class="headerlink" href="#bitmap-outline-advance-width-mismatch" title="Permalink to this headline">¶</a></h2>
 <p>If you have a font with embedded bitmaps, then you would expect that the bitmap
 advance width would be the same as the outline glyph’s advance width (with
-approprate scaling and rounding, of course). This checks to ensure that that is
+approprate scaling and rounding, of course). This checks to ensure that is
 true.</p>
 </div>
 <div class="section" id="check-multiple-unicode">

--- a/docs/ui/dialogs/statemachine.html
+++ b/docs/ui/dialogs/statemachine.html
@@ -168,7 +168,7 @@ transformation to the marked glyph.</p>
 <dl>
 <dt>Indic</dt><dd><p>In addition to a “mark”ed glyph, indic transformations also have a the
 concept of a “last” glyph. There are 16 transformations which may be applied
-the the glyphs between the “mark”ed and “last” glyphs. Suppose the glyph
+the glyphs between the “mark”ed and “last” glyphs. Suppose the glyph
 stream looks like</p>
 <p>abcdef</p>
 <p>And “a” was “mark”ed and “d” was “last” then a transition “AxD =&gt; DxA” refers

--- a/docs/ui/dialogs/validation.html
+++ b/docs/ui/dialogs/validation.html
@@ -123,7 +123,7 @@ very close to the end-points of a spline (because when you round those points to
 integers they may end up lying right on top of the end points, or because
 rounding the control points may cause significant distortion of the spline’s
 shape). Unfortunately these are exactly the cases which are most likely to
-occur. So FontForge has two variants of Add Extrema, which which adds what it
+occur. So FontForge has two variants of Add Extrema, which adds what it
 thinks are “Good” extrema, and one which will add all extrema even if they are
 likely to cause problems later.</p>
 <p>When the Add Good Extrema command does not fix your problem, you may be better

--- a/docs/ui/mainviews/charview.html
+++ b/docs/ui/mainviews/charview.html
@@ -544,7 +544,7 @@ patents</p>
 </div>
 <p>The image to the right shows an example of this mode. You invoke it with
 <a class="reference internal" href="../menus/hintsmenu.html#hintsmenu-debug"><span class="std std-ref">Hints-&gt;Debug</span></a>, and as with the grid-fit view above you
-must establish a pointsize and and resolution. The view divides into two panes,
+must establish a pointsize and resolution. The view divides into two panes,
 the left of which is similar to the grid fit view above (except that it changes
 as you step through the instructions), the right pane provides a list of the
 instructions to be executed.</p>

--- a/docs/ui/mainviews/metricsview.html
+++ b/docs/ui/mainviews/metricsview.html
@@ -667,7 +667,7 @@ in em-units and being, roughly, the average error in how two different glyphs
 interact with other glyphs). A value of 1 is very picky and almost all classes
 will have one member. A value of 20 (in a 1000em font) is fairly loose.</p>
 <p>The <code class="docutils literal notranslate"><span class="pre">Default</span> <span class="pre">Separation</span></code> and <code class="docutils literal notranslate"><span class="pre">Min</span> <span class="pre">Kern</span></code> fields are used in AutoKerning. The
-goal of kerning to to make the optical separation between all glyphs to be
+goal of kerning to make the optical separation between all glyphs to be
 constant, and the <code class="docutils literal notranslate"><span class="pre">Default</span> <span class="pre">Separation</span></code> field specifies that desired value. The
 <code class="docutils literal notranslate"><span class="pre">Min</span> <span class="pre">Kern</span></code> value is simply to prevent the dialog from filling with useless
 junk. If AutoKerning suggests that two glyphs should be kerned by 1 em unit then

--- a/docs/ui/menus/viewmenu.html
+++ b/docs/ui/menus/viewmenu.html
@@ -118,7 +118,7 @@ which you may type either:</p>
 <li><p>A number (in either decimal or hex) indicating the glyph you are interested
 in, in the current encoding</p></li>
 <li><p>A hex number ,preceded by “U+” or “uni” or “u”, indicating the character you
-are interested in in unicode.</p></li>
+are interested in unicode.</p></li>
 <li><p>A decimal number, preceded by “glyph” ,indicating the glyph index in the
 original glyph list.</p></li>
 <li><p>A ku ten representation of a CJK font (two comma separated numbers)</p></li>

--- a/en-US/project/oldchangelog.md
+++ b/en-US/project/oldchangelog.md
@@ -161,13 +161,13 @@ title: Older changes to FontForge
         introduced garbage).
     -   We didn't think we could read in a kerning subtable (class or
         pair) with device tables, so we converted them to pst data. We
-        can read them in in optimized form and we should do so.
+        can read them in optimized form and we should do so.
     -   Alexej points out that if a glyph has
         "instructions\_out\_of\_date" set on it, then setting the
         instructions via a script should clear the bit -- but didn't.
     -   Werner points out that if a type2 charstring contained a
         sequence \<num\> endchar then ff would set the width of the
-        charater even if the the width had already been set. Width can
+        charater even if the width had already been set. Width can
         only be set on first stack clearing operation, any extra params
         on subsequent calls get ignored.
 
@@ -403,7 +403,7 @@ title: Older changes to FontForge
     -   Revert glyph had some stray memory references.
     -   Add two proposed language tags for IPA use (one for IPA and one
         for Americanist).
-    -   In an empty python layer layer.boundingBox should return a tuple
+    -   In an empty python layer.boundingBox should return a tuple
         of 4 zeros, instead it returned a tuple of 2 zeros and 2 random
         garbage values.
     -   Validate dlg's scrollbar was broken, and you couldn't drag the
@@ -2518,7 +2518,7 @@ title: Older changes to FontForge
     -   If the width of a glyph changed in the metrics view then that
         was not synchronized to dependent glyphs.
     -   Enforce the "Use My Metrics" bit of a reference.
-         In TrueType, if this bit is set on a reference then then width
+         In TrueType, if this bit is set on a reference then width
         of the containing glyph will be the same as that of the
         reference.
          So don't let the user change the width of such glyphs. (and add


### PR DESCRIPTION
Those has been found thanks to the execution accross all the docs of
this rudimentary regex: `\b([^\s\d]{2,5})\s+\1\b`

It is inspired from the the one described by Jeffrey Friedl in his book
`Mastering Regular Expression`.