### PR TITLE
fix mac download link syntax error

### DIFF
--- a/en-US/downloads/mac-dl.md
+++ b/en-US/downloads/mac-dl.md
@@ -8,7 +8,7 @@ archive_extension: ".dmg"
 FontForge is a UNIX application, so it doesn't behave 100% like a normal Mac Application.
 OS X 10.12 or later is required.
 
-Download and install [FontForge 2020-11-07]https://github.com/fontforge/fontforge/releases/download/20201107/FontForge-2020-11-07-21ad4a1.app.dmg)
+Download and install [FontForge 2020-11-07](https://github.com/fontforge/fontforge/releases/download/20201107/FontForge-2020-11-07-21ad4a1.app.dmg)
 
 <a class="btn btn-primary btn-large default" data-toggle="collapse" href="#collapseOld" aria-expanded="false" aria-controls="collapseOld">
   For releases before 2019-03-17


### PR DESCRIPTION
#153 had a little tiny typo in the link, this fixes that