### PR TITLE
Note past support from the Libre Font Fund

### DIFF
--- a/en-US/donate.md
+++ b/en-US/donate.md
@@ -6,7 +6,7 @@ title: Fund New Features
 
 FontForge development is limited by the availability of volunteered time and talent. Contributing financially ensures faster development of new features and fixing of issues.
 
-FontForge can accept donations by PayPal. Note that as these are not routed through a 501(c)3 organization they are not tax deductible.
+FontForge can accept donations by PayPal. Note that, as these are not routed through a 501(c)3 organization, they are not tax deductible.
 
 <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
 <input type="hidden" name="cmd" value="_s-xclick">

--- a/en-US/donate.md
+++ b/en-US/donate.md
@@ -6,7 +6,7 @@ title: Fund New Features
 
 FontForge development is limited by the availability of volunteered time and talent. Contributing financially ensures faster development of new features and fixing of issues.
 
-FontForge can accept donations by PayPal, but these are not routed through a 501(c)3 organization and are thus not tax deductible.
+FontForge can accept donations by PayPal. Note that as these are not routed through a 501(c)3 organization they are not tax deductible.
 
 <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
 <input type="hidden" name="cmd" value="_s-xclick">
@@ -14,7 +14,5 @@ FontForge can accept donations by PayPal, but these are not routed through a 501
 <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
 <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
 </form>
-
-The [Libre Font Fund](https://www.tug.org/fonts/librefontfund.html), a mission of the TeX User Group, is able to accept donations for FontForge development in a way that qualifies for charitable deductions in the United States.
 
 If you would like to fund a specific issue, please see [When Things Go Wrong With FontForge Itself](http://designwithfontforge.com/en-US/When_Things_Go_Wrong_With_Fontforge_Itself.html)

--- a/en-US/project/acknowledgements.md
+++ b/en-US/project/acknowledgements.md
@@ -9,6 +9,13 @@ This page exists to acknowledge everyone who's helped out with FontForge. Many t
 (Actually the list should be far longer than this,
 but as time goes on there are just too many people to thank.)
 
+Sponsors
+--------
+
+The [TeX Users Group](https://tug.org) sponsored a [variety of FontForge development
+projects](https://tug.org/fonts/librefontfund.html) over the years, and welcomes
+[new grant proposals](https://tug.org/tc/devfund/application.html).
+
 
 Sample Text
 -----------


### PR DESCRIPTION
and remove link from donate page as the fund is now retired.

(These changes are based on the suggestions and language of Karl Berry at TUG.) 