### PR TITLE
Fix dead links in documentation

### DIFF
--- a/docs/appendices/bibliography.html
+++ b/docs/appendices/bibliography.html
@@ -99,7 +99,7 @@ late 2007).</p></li>
 <li><p>I can’t find microsoft’s docs for pfm files any more, I think the format may be
 obsolete having been replaced by ntf.</p></li>
 <li><p><a class="reference external" href="http://partners.adobe.com/public/developer/en/font/5178.PFM.pdf">Adobe’s notes on PFM files for two byte fonts</a></p></li>
-<li><p><a class="reference external" href="http://homepages.muenchen.org/bm134751/pfm_fmt_en.html">Third Party description</a></p></li>
+<li><p><a class="reference external" href="https://ghostarchive.org/archive/G3ZQD">Third Party description</a></p></li>
 </ul>
 </li>
 <li><p><a class="reference external" href="http://msdn.microsoft.com/library/default.asp?url=/library/en-us/graphics/hh/graphics/pscript_7twn.asp">NTF</a></p>
@@ -145,14 +145,14 @@ variations)</p></li>
 variations)</p></li>
 </ul>
 </li>
-<li><p id="bibliography-opentype"><a class="reference external" href="http://partners.adobe.com/public/developer/opentype/index_spec.html">OpenType</a>
+<li><p id="bibliography-opentype"><a class="reference external" href="https://docs.microsoft.com/en-us/typography/opentype/spec/">OpenType</a>
 (postscript embedded in a truetype wrapper, or advanced typography tables in a
 truetype wrapper)</p>
 <ul class="simple">
 <li><p>PostScript
 <a class="reference external" href="http://partners.adobe.com/public/developer/en/font/5177.Type2.pdf">Type2</a></p></li>
 <li><p><a class="reference external" href="http://partners.adobe.com/public/developer/en/font/5176.CFF.pdf">CFF</a></p></li>
-<li><p><a class="reference external" href="http://partners.adobe.com/public/developer/opentype/index_spec.html">Adobe’s version of file format</a></p>
+<li><p><a class="reference external" href="https://docs.microsoft.com/en-us/typography/opentype/spec/">Microsoft's version of file format</a></p>
 <ul>
 <li><p><a class="reference external" href="http://partners.adobe.com/public/developer/opentype/gdk/topic.html">SING Gaiji extention</a>
 (more information is available in the documentation subdirectory of the Glyphlet
@@ -199,7 +199,7 @@ Font Format, mozilla’s compressed sfnt format</p></li>
 <li><p>TeX font formats</p>
 <ul>
 <li><p><a class="reference external" href="http://www.ctan.org/tex-archive/systems/knuth/local/mfware/pktype.web">pk packed bitmap format</a></p></li>
-<li><p><a class="reference external" href="http://www.ctan.org/tex-archive/systems/knuth/mfware/gftype.web">gf generic font (bitmap) format</a></p></li>
+<li><p><a class="reference external" href="http://www.ctan.org/tex-archive/systems/knuth/mfware/">gf generic font (bitmap) format</a></p></li>
 <li><p><a class="reference external" href="http://www.ctan.org/tex-archive/systems/knuth/texware/tftopl.web">tfm metrics format</a></p></li>
 <li><p>To make these viewable you probably want to do something like:</p>
 <p>$ weave pktype.web</p>
@@ -212,13 +212,13 @@ Font Format, mozilla’s compressed sfnt format</p></li>
 composing, reordering, spacing, etc. glyphs)</p></li>
 <li><p>Palm pilot fonts (pdb files)</p>
 <ul class="simple">
-<li><p><a class="reference external" href="http://www.palmos.com/dev/support/docs/palmos/PalmOSReference/Font.html">font record format</a></p></li>
-<li><p><a class="reference external" href="http://www.palmos.com/dev/support/docs/fileformats/Intro.html#970318">pdb file format</a></p></li>
+<li><p><a class="reference external" href="https://lost-contact.mit.edu/afs/cs.pitt.edu/public/khalifa/449/DevStudioDocumentations/PalmOSReference/Font.html">font record format</a></p></li>
+<li><p><a class="reference external" href="https://hwiegman.home.xs4all.nl/fileformats/pdb/pdb.htm">pdb file format</a></p></li>
 </ul>
 </li>
 <li><p><a class="reference external" href="http://www.bitstream.com/categories/developer/truedoc/pfrspec.html">OpenDoc</a>.
 Sadly Proprietary so I shan’t support it.</p></li>
-<li><p><a class="reference external" href="http://www.pinknoise.demon.co.uk/Docs/Arc/Fonts/Formats.html">Acorn RISC OS font format</a>
+<li><p><a class="reference external" href="https://ghostarchive.org/fontinfo/formats.txt">Acorn RISC OS font format</a>
 (these fonts are often zipped up with a non-standard zip).</p></li>
 <li><p>Ikarus IK format is documented in Peter Karow’s book * Digital Formats for
 Typefaces,* Appendices G&amp;I. (copies may still be available from
@@ -232,7 +232,7 @@ unicode)</p></li>
 <ul class="simple">
 <li><p>TTX – TrueType XML</p></li>
 <li><p><a class="reference external" href="http://unifiedfontobject.org/">UFO</a> &amp;
-<a class="reference external" href="http://unifiedfontobject.org/storageformats/glif.html">GLIF</a> – Unified font
+<a class="reference external" href="https://unifiedfontobject.org/versions/ufo3/glyphs/glif/">GLIF</a> – Unified font
 objects &amp; Glyph Interchange Format</p></li>
 </ul>
 </li>
@@ -240,7 +240,7 @@ objects &amp; Glyph Interchange Format</p></li>
 <p>Other font links</p>
 <ul class="simple">
 <li><p><a class="reference external" href="http://partners.adobe.com/public/developer/en/font/5040.Download_Fonts.pdf">Adobe’s downloadable font spec</a></p></li>
-<li><p><a class="reference external" href="http://partners.adobe.com/asn/tech/type/ftechnotes.jsp">Adobe’s technical notes</a></p></li>
+<li><p><a class="reference external" href="https://web.archive.org/web/20040623083036/http://partners.adobe.com/asn/tech/type/ftechnotes.jsp">Adobe’s technical notes</a></p></li>
 <li><p><a class="reference external" href="http://partners.adobe.com/asn/acrobat/sdk/public/docs/FontPolicies.pdf">Adobe’s Font Policies document</a></p></li>
 <li><p><a class="reference external" href="http://www.adobe.com/products/postscript/pdfs/PLRM.pdf">PostScript reference manual</a></p>
 <ul>
@@ -275,7 +275,7 @@ by Jehan Janbi, 2016</p></li>
 <h2>Related software<a class="headerlink" href="#related-software" title="Permalink to this headline">¶</a></h2>
 <ul class="simple">
 <li><p><a class="reference external" href="http://www.gimp.org/">Gimp</a></p></li>
-<li><p><a class="reference external" href="http://gug.sunsite.dk/">Gimp users group</a></p></li>
+<li><p><a class="reference external" href="https://www.gimpusers.com/">Gimp users group</a></p></li>
 </ul>
 </div>
 <div class="section" id="unicode">
@@ -304,12 +304,12 @@ meaning attached to the mapping)</p></li>
 <li><p><a class="reference external" href="http://www.unicode.org/iso15924-en.html">ISO 15924 script list</a></p></li>
 </ul>
 </li>
-<li><p><a class="reference external" href="http://www.babelstone.co.uk/Unicode/Bloopers.html">Unicode Bloopers</a></p></li>
+<li><p><a class="reference external" href="https://unicode.org/mail-arch/unicode-ml/y2005-m04/0365.html">Unicode Bloopers</a></p></li>
 <li><p><a class="reference external" href="http://partners.adobe.com/public/developer/opentype/index_glyph.html">PostScript Unicode names</a></p>
 <ul>
-<li><p><a class="reference external" href="http://partners.adobe.com/public/developer/en/opentype/aglfn13.txt">Glyph names for new fonts</a>
+<li><p><a class="reference external" href="https://ghostarchive.org/fontinfo/aglfn13.txt">Glyph names for new fonts</a>
 (these are the names FontForge automatically assigns to glyphs)</p></li>
-<li><p><a class="reference external" href="http://partners.adobe.com/public/developer/en/opentype/glyphlist.txt">Adobe Glyph Names</a>
+<li><p><a class="reference external" href="https://ghostarchive.org/fontinfo/glyphlist.txt">Adobe Glyph Names</a>
 provides further synonyms</p></li>
 <li><p><a class="reference external" href="http://partners.adobe.com/public/developer/opentype/index_glyph2.html">Glyph name limitations</a></p></li>
 </ul>
@@ -325,7 +325,7 @@ provides further synonyms</p></li>
 <div class="section" id="other-encodings">
 <span id="bibliography-encodings"></span><h3>Other Encodings<a class="headerlink" href="#other-encodings" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
-<li><p><a class="reference external" href="http://www.microsoft.com/globaldev/reference/wincp.asp">Microsoft’s Codepages</a>,
+<li><p><a class="reference external" href="https://ghostarchive.org/archive/gRp5Z">Microsoft’s Codepages</a>,
 and at the
 <a class="reference external" href="http://www.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/WINDOWS/">unicode site</a></p></li>
 <li><p><a class="reference external" href="http://www.unicode.org/Public/MAPPINGS/VENDORS/APPLE/">Mac Encodings</a></p></li>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -541,7 +541,7 @@ laws governing fonts in other countries. There is a
 <a class="reference external" href="http://typophile.com/node/42709">thread on typophile</a> which discusses
 this.</p>
 <p>There is a good summary at the
-<a class="reference external" href="http://www.fontembeddng.com/fonts-and-the-law">font embedding</a> website.</p>
+<a class="reference external" href="http://web.archive.org/web/20080712192401/http://www.fontembedding.com/fonts-and-the-law/">font embedding</a> (archived) website.</p>
 </dd>
 </dl>
 <dl id="faq-pointsize">
@@ -661,7 +661,7 @@ know of two licenses specifically produced for fonts:</p>
 recommend. <cite><a href="appendices/OFL-Unofficial.html" target="_top">Unofficial translations of the OFL.</a></cite> These are not legally
 binding but may help non-English speakers get the intent of the license.</p>
 </li>
-<li><p><a class="reference external" href="http://www.gnome.org/fonts/#Final_Bitstream_Vera_fonts">The license Bitstream used to release the Vera fonts</a></p></li>
+<li><p><a class="reference external" href="https://download.gnome.org/sources/ttf-bitstream-vera/1.10/">The license Bitstream used to release the Vera fonts</a></p></li>
 </ul>
 <p>The <a class="reference external" href="http://www.gnu.org/licenses/gpl.html">GNU General Public License</a> is
 also often used.</p>
@@ -820,7 +820,7 @@ encoding. See the <a class="reference internal" href="#faq-how-mac"><span class=
 information.</p>
 <p>I’ve also written <a class="reference external" href="http://fondu.sourceforge.net/">some utilities</a>
 designed to convert from one format to another and they may prove useful.</p>
-<p><a class="reference external" href="http://babel.uoregon.edu/yamada/fontconversionfaq.html">University of Oregon has some links that might be helpful</a>.</p>
+<p><a class="reference external" href="https://ghostarchive.org/archive/Pf6uh">University of Oregon has some links that might be helpful</a>.</p>
 <p>Once you’ve converted your fonts you just drop them into the System Folder
 and they should be available after that.</p>
 </dd>
@@ -1280,7 +1280,7 @@ do:</p>
 <p>Figure out what your encoding looks like. Often this will involve searching
 around the web to find an example of that encoding. For instance if you want
 a devanagari encoding you might look at
-<a class="reference external" href="http://www.cwi.nl/~dik/english/codes/indic.html">a site which shows the ISCII encodings</a></p>
+<a class="reference external" href="https://ghostarchive.org/archive/DWyYT">a site which shows the ISCII encodings</a></p>
 <p>These encodings only show the top 96 characters, presumably the others are
 the same as US ASCII. Look at the images and figure out how they map to
 unicode (or more precisely what the appropriate postscript names are for

--- a/docs/index.html
+++ b/docs/index.html
@@ -562,7 +562,7 @@ vowel marks.</p>
 <p>Within fontforge every glyph will have a name. Generally the glyph name will be
 something that provides information about what the glyph looks like so the name
 for the glyph representing “9” is “nine”. Adobe has established a
-<a class="reference external" href="http://partners.adobe.com/public/developer/en/opentype/aglfn13.txt">standard for what names may be assigned to what glyphs</a>,
+<a class="reference external" href="https://ghostarchive.org/fontinfo/aglfn13.txt">standard for what names may be assigned to what glyphs</a>,
 and when producing a font for general use it is best to stick to that standard
 (Acrobat uses the glyph names and recognizes the standard ones. If you try and
 use “neuf” for “nine” Acrobat will not recognize it and surprising things will

--- a/docs/techref/TrueOpenTables.html
+++ b/docs/techref/TrueOpenTables.html
@@ -38,8 +38,7 @@
   <div class="section" id="truetype-and-opentype-tables-supported-by-fontforge">
 <h1>TrueType and OpenType tables supported by FontForge<a class="headerlink" href="#truetype-and-opentype-tables-supported-by-fontforge" title="Permalink to this headline">¶</a></h1>
 <p><a class="reference external" href="http://developer.apple.com/fonts/TTRefMan/RM06/Chap6.html">Apple</a>,
-<a class="reference external" href="http://www.microsoft.com/typography/tt/tt.htm">MS</a> and
-<a class="reference external" href="http://partners.adobe.com/public/developer/opentype/index_spec.html">Adobe</a>
+  <a class="reference external" href="http://www.microsoft.com/typography/tt/tt.htm">MS</a>
 all have their descriptions of TrueType and OpenType. MS and Adobe’s versions
 are essentially the same, while Apple’s differ significantly from either.</p>
 <table class="colwidths-given docutils align-default">
@@ -155,7 +154,7 @@ which will cover code points outside of the BMP.</p>
 glyphs.</p>
 </td>
 <td><p><a class="reference external" href="http://developer.apple.com/fonts/TTRefMan/RM06/Chap6cmap.html">cmap</a></p></td>
-<td><p><a class="reference external" href="http://partners.adobe.com/public/developer/opentype/index_cmap.html">cmap</a></p></td>
+<td><p><a class="reference external" href="https://docs.microsoft.com/en-us/typography/opentype/spec/cmap">cmap</a></p></td>
 </tr>
 <tr class="row-odd"><td><p>cvar</p></td>
 <td><p>variations on cvt table</p></td>
@@ -260,7 +259,7 @@ approximately equivalent to Apple’s ‘prop’ and ‘lcar’ tables combined.
 <li></li>
 </ul>
 </td>
-<td><p><a class="reference external" href="http://partners.adobe.com/public/developer/opentype/index_table_formats5.html">GDEF</a></p></td>
+<td><p><a class="reference external" href="https://docs.microsoft.com/en-us/typography/opentype/spec/gdef">GDEF</a></p></td>
 </tr>
 <tr class="row-even"><td><p>glyf</p></td>
 <td><p>glyph outline</p></td>
@@ -278,7 +277,7 @@ Vaguely equivalent to ‘kern’ and ‘opbd’ tables.</p></td>
 <li></li>
 </ul>
 </td>
-<td><p><a class="reference external" href="http://partners.adobe.com/public/developer/opentype/index_table_formats1.html">GPOS</a></p></td>
+<td><p><a class="reference external" href="https://docs.microsoft.com/en-us/typography/opentype/spec/gpos">GPOS</a></p></td>
 </tr>
 <tr class="row-even"><td><p>GSUB</p></td>
 <td><p>glyph substitution</p></td>
@@ -429,7 +428,7 @@ comments, and colors.I describe its format <a class="reference internal" href="n
 <td><p>This table provides some additional postscript information (italic angle),
 but mostly it provides names for all glyphs.</p></td>
 <td><p><a class="reference external" href="http://developer.apple.com/fonts/TTRefMan/RM06/Chap6post.html">post</a></p></td>
-<td><p><a class="reference external" href="http://partners.adobe.com/public/developer/opentype/index_post.html">post</a></p></td>
+<td><p><a class="reference external" href="https://docs.microsoft.com/en-us/typography/opentype/spec/post">post</a></p></td>
 </tr>
 <tr class="row-even"><td><p>prep</p></td>
 <td><p>cvt program</p></td>

--- a/docs/techref/gposgsub.html
+++ b/docs/techref/gposgsub.html
@@ -59,19 +59,20 @@ contains information on baseline placement and line heights.</p>
 <p>This page assumes basic familiarity with the abilities of the tables, for more
 information on them read, study and inwardly digest the OpenType docs on:</p>
 <ul class="simple">
-<li><p><a class="reference external" href="http://partners.adobe.com/public/developer/opentype/index_table_formats.html">The header for both GPOS and GSUB</a></p></li>
-<li><p><a class="reference external" href="http://partners.adobe.com/public/developer/opentype/index_table_formats2.html">The GPOS table</a>,
+<li><p><a class="reference external" href="https://docs.microsoft.com/en-us/typography/opentype/spec/chapter2">The header for both GPOS and GSUB</a></p></li>
+<li><p><a class="reference external" href="https://docs.microsoft.com/en-us/typography/opentype/spec/gpos">The GPOS table</a>,
 for positioning glyphs</p></li>
-<li><p><a class="reference external" href="http://partners.adobe.com/public/developer/opentype/index_table_formats1.html">The GSUB table</a>,
+<li><p><a class="reference external" href="https://docs.microsoft.com/en-us/typography/opentype/spec/gsub">The GSUB table</a>,
 for substituting glyphs</p></li>
-<li><p><a class="reference external" href="http://partners.adobe.com/public/developer/opentype/index_table_formats5.html">The GDEF table</a>,
+<li><p><a class="reference external" href="https://docs.microsoft.com/en-us/typography/opentype/spec/gdef">The GDEF table</a>,
 for classifying glyphs and for providing a ligature caret table</p></li>
 <li><p><a class="reference external" href="http://partners.adobe.com/public/developer/opentype/index_base.html">The BASE table</a>,
 for baseline placement</p></li>
-<li><p><a class="reference external" href="http://partners.adobe.com/public/developer/opentype/index_tag3.html">The list of feature tags supported by OpenType</a></p></li>
-<li><p><a class="reference external" href="http://partners.adobe.com/public/developer/opentype/index_tag1.html">The list of script tags supported by OpenType</a></p></li>
-<li><p><a class="reference external" href="http://partners.adobe.com/public/developer/opentype/index_tag2.html">The list of language tags supported by OpenType</a></p></li>
-<li><p><a class="reference external" href="http://partners.adobe.com/public/developer/opentype/index_tag4.html">The list of baseline tags supported by OpenType</a></p></li>
+  
+<li><p><a class="reference external" href="https://ghostarchive.org/archive/QVjaK">The list of feature tags supported by OpenType</a></p></li>
+<li><p><a class="reference external" href="https://ghostarchive.org/archive/ziBGt">The list of script tags supported by OpenType</a></p></li>
+<li><p><a class="reference external" href="https://ghostarchive.org/archive/Bsanr">The list of language tags supported by OpenType</a></p></li>
+<li><p><a class="reference external" href="https://ghostarchive.org/archive/IFjjd">The list of baseline tags supported by OpenType</a></p></li>
 </ul>
 <p>The basic idea of the GPOS and GSUB tables is that each script (or language
 within a script) has a set of “features” that are available to it. A feature in

--- a/docs/techref/pcf-format.html
+++ b/docs/techref/pcf-format.html
@@ -109,7 +109,7 @@ can be altered by adding one of the mask bits above.</p>
 in
 <a class="reference external" href="http://ftp.x.org/pub/R6.4/xc/doc/specs/XLFD/xlfd.tbl.ms">xc/doc/specs/XLFD/xlfd.tbl.ms</a>
 or
-<a class="reference external" href="http://rpmfind.net/linux/RPM/redhat/6.2/i386/XFree86-doc-3.3.6-20.i386.html">here</a>
+<a class="reference external" href="https://web.archive.org/web/20040222142023/http://rpmfind.net/linux/RPM/redhat/6.2/i386/XFree86-doc-3.3.6-20.i386.html">here</a>
 (the X protocol does not limit these atoms so others could be defined for some
 fonts).</p>
 <p>To find the name of a property: <code class="docutils literal notranslate"><span class="pre">strings</span> <span class="pre">+</span> <span class="pre">props[i].name_offset</span></code></p>

--- a/docs/techref/pcf-format.html
+++ b/docs/techref/pcf-format.html
@@ -269,7 +269,7 @@ character in em-units (1/1000ths of an em).</p>
 <p>Other sources of info:</p>
 <ul class="simple">
 <li><p><a class="reference external" href="http://www.tsg.ne.jp/GANA/S/pcf2bdf/pcf.pdf">http://www.tsg.ne.jp/GANA/S/pcf2bdf/pcf.pdf</a></p></li>
-<li><p><a class="reference external" href="http://myhome.hananet.net/~bumchul/xfont/pcf.txt">http://myhome.hananet.net/~bumchul/xfont/pcf.txt</a></p></li>
+<li><p><a class="reference external" href="http://ghostarchive.org/fontinfo/pcf.txt">http://myhome.hananet.net/~bumchul/xfont/pcf.txt (archived link:http://ghostarchive.org/fontinfo/pcf.txt)</a></p></li>
 </ul>
 </div>
 </div>

--- a/docs/ui/dialogs/contextchain.html
+++ b/docs/ui/dialogs/contextchain.html
@@ -82,13 +82,13 @@ example is worked out in detail in the <a class="reference internal" href="../..
 </div>
 <div class="section" id="more-complete-descriptions">
 <h2>More complete descriptions<a class="headerlink" href="#more-complete-descriptions" title="Permalink to this headline">¶</a></h2>
-<p>For more information on contextual lookups see Adobe’s Docs:</p>
+<p>For more information on contextual lookups see Microsoft’s Docs:</p>
 <ul class="simple">
-<li><p><a class="reference external" href="http://partners.adobe.com/public/developer/opentype/index_table_formats2.html">The GPOS table</a>,
+<li><p><a class="reference external" href="https://docs.microsoft.com/en-us/typography/opentype/spec/gpos">The GPOS table</a>,
 for positioning glyphs</p></li>
-<li><p><a class="reference external" href="http://partners.adobe.com/public/developer/opentype/index_table_formats1.html">The GSUB table</a>,
+<li><p><a class="reference external" href="https://docs.microsoft.com/en-us/typography/opentype/spec/gsub">The GSUB table</a>,
 for substituting glyphs</p></li>
-<li><p><a class="reference external" href="http://partners.adobe.com/public/developer/opentype/index_tag3.html">The feature tag registry</a>.</p></li>
+<li><p><a class="reference external" href="https://docs.microsoft.com/en-us/typography/opentype/spec/ttoreg">The feature tag registry</a>.</p></li>
 </ul>
 </div>
 <div class="section" id="how-do-these-relate-to-apple-advanced-typography-features">

--- a/docs/ui/dialogs/fontinfo.html
+++ b/docs/ui/dialogs/fontinfo.html
@@ -531,7 +531,7 @@ same. This should only be specified if it differs from the family</p>
 <p>These are described in the
 <a class="reference external" href="http://fonts.apple.com/TTRefMan/RM06/Chap6name.html">original true type docs</a>,
 but they apply to
-<a class="reference external" href="http://partners.adobe.com/asn/tech/type/opentype/recom.jsp">open type</a> as
+<a class="reference external" href="https://docs.microsoft.com/en-us/typography/opentype/spec/recom">open type</a> as
 well.</p>
 <p>These settings specify strings for the windows platform with unicode encoding.</p>
 <p>Generally fonts will have a fairly complete set of strings in the American


### PR DESCRIPTION
There are many dead links in the documentation. I first replaced them by looking for the original or similar source. For example, for the dead Adobe links, I instead linked to the MSFT typography docs, which had similar information. When this approach didn't work, i used an archive link instead.
