### PR TITLE
Corrected Image Sources in the Overview Page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -100,11 +100,11 @@ other scripts like arabic require them.</p>
 letter “A” is a character, while <img alt="As" src="_images/As.png" /> are all glyphs that represent an “A”.
 In latin fonts there is often a single glyph for every character and a single
 character for every glyph, but not always – in renaissance printing there were
-two glyphs for a lower-case s, <img alt="short-long-s" src="_images/arabic-seen.png" /> the short and the long s. Whereas
+two glyphs for a lower-case s, <img alt="short-long-s" src="_images/short-long-s.png" /> the short and the long s. Whereas
 a ligature is an example of a glyph that represents two (or more) characters.
 In arabic most of the letters (characters) have at least four different glyphs,
 the appropriate glyph being determined by the letters around it. Here are four
-forms of the arabic character “seen” <img alt="arabic-seen" src="_images/short-long-s.png" />.</p>
+forms of the arabic character “seen” <img alt="arabic-seen" src="_images/arabic-seen.png" />.</p>
 </div>
 <div class="section" id="what-is-an-outline-font-what-is-a-bitmap-font">
 <h3>What is an outline font? What is a bitmap font?<a class="headerlink" href="#what-is-an-outline-font-what-is-a-bitmap-font" title="Permalink to this headline">¶</a></h3>
@@ -245,7 +245,7 @@ and the font has 1000 units to the em. Suppose a someone displays that dash at
 points. On a 72 dot per inch screen where a pixel is almost exactly one point,
 the dash will be 6 pixels long.</p>
 <img alt="_images/sidebearings.png" class="align-right" src="_images/sidebearings.png" />
-<p>Every glyph has its own coördinate system. The font’s
+<p>Every glyph has its own coordinate system. The font’s
 <a class="reference internal" href="#overview-baseline"><span class="std std-ref">baseline</span></a> (the line upon which most latin glyphs will
 rest) is 0 in the vertical direction. The horizontal origin is where the glyph
 will start being drawn (what is “drawn” will usually be empty space for a short


### PR DESCRIPTION
Letter seen forms and short long S images were reversed.
Also, "coordinate" has no diaeresis!