### PR TITLE
Copyright year will auto update every year

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -71,7 +71,9 @@
         <p><a href="https://github.com/fontforge/fontforge.github.io/blob/master
 					{{ page.url | split: '/' | join: '/' }}.md">Edit this page</a> - <a href="/en-US/site/">Learn how</a></p>
 -->
-	  	<small class="copyright">Copyright &copy; 2000 &ndash; 2015, George Williams and the FontForge Project contributors. Shared freely under the project license.</small>
+	  	<small class="copyright">Copyright &copy; 2000 &ndash; <script type="text/javascript">
+  document.write(new Date().getFullYear());
+</script>, George Williams and the FontForge Project contributors. Shared freely under the project license.</small>
 	  </div>
 	</div>
 	</footer>


### PR DESCRIPTION
Sometimes when the copyright year is not updated, it gives out the impression that it is not being maintained. Here the copyright year was given as 2015.